### PR TITLE
feat: redesign login interface

### DIFF
--- a/src/app/layout-client.tsx
+++ b/src/app/layout-client.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import SideBar from "./components/sidebar";
+
+export default function LayoutClient({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isAuthPage = pathname === "/login";
+
+  if (isAuthPage) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="grid h-dvh md:grid-cols-[256px_1fr] grid-cols-1">
+      <SideBar />
+      <main className="overflow-auto p-4 md:p-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import SideBar from "./components/sidebar";
+import LayoutClient from "./layout-client";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,10 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#f2f2f2] text-black`}
       >
-        <div className="grid h-dvh md:grid-cols-[256px_1fr] grid-cols-1">
-          <SideBar />
-          <main className="overflow-auto p-4 md:p-6">{children}</main>
-        </div>
+        <LayoutClient>{children}</LayoutClient>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,36 +1,67 @@
-import Image from "next/image";
 import { login } from "./actions";
+import { Inter } from "next/font/google";
+import { FcGoogle } from "react-icons/fc";
+import { FaApple } from "react-icons/fa";
+
+const inter = Inter({ subsets: ["latin"] });
 
 export default function LoginPage() {
   return (
-    <div>
-      <div className="absolute z-0 w-screen h-screen">
-        <Image
-          src="/vet1.avif"
-          alt="Logo"
-          fill
-          style={{ objectFit: "cover" }}
-          unoptimized
-        />
-        <div className="absolute inset-0 bg-black/40" />
-      </div>
-      <div className="p-20 relative">
-        <form className="flex flex-col gap-4 max-w-lg mx-auto mt-52 bg-gray-300 p-10 rounded">
-          <label htmlFor="email">Email:</label>
-          <input id="email" name="email" type="email" required />
-          <label htmlFor="password">Password:</label>
-          <input id="password" name="password" type="password" required />
-          <div className="flex gap-10 justify-center mt-4">
-            <button
-              className="bg-gray-600 p-2 rounded-xl min-w-[200px] text-white"
-              formAction={login}
-            >
-              Iniciar sesión
-            </button>
-            {/* <button className="bg-gray-300 p-2 rounded-xl min-w-[200px]" formAction={signup}>Sign up</button> */}
-          </div>
-        </form>
-      </div>
+    <div
+      className={`${inter.className} flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 via-indigo-100 to-purple-200 p-4`}
+    >
+      <form className="w-full max-w-md space-y-6 rounded-2xl bg-white p-8 shadow-lg">
+        <div className="space-y-2 text-center">
+          <h1 className="text-3xl font-semibold text-gray-900">Welcome Back</h1>
+          <p className="text-sm text-gray-500">Please sign in to your account</p>
+        </div>
+        <div className="space-y-4">
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            placeholder="Email"
+            className="w-full rounded-md border border-gray-300 bg-transparent px-4 py-2 text-sm text-gray-900 placeholder-gray-400 transition hover:border-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            placeholder="Password"
+            className="w-full rounded-md border border-gray-300 bg-transparent px-4 py-2 text-sm text-gray-900 placeholder-gray-400 transition hover:border-gray-400 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+        <button
+          className="w-full rounded-md bg-gradient-to-r from-blue-600 to-purple-600 px-4 py-2 text-white shadow transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-purple-500 active:scale-[0.98]"
+          formAction={login}
+        >
+          Sign In
+        </button>
+        <a
+          href="#"
+          className="block text-center text-sm text-blue-600 transition hover:underline"
+        >
+          Forgot password?
+        </a>
+        <div className="flex items-center justify-center gap-4">
+          <button
+            type="button"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 bg-white shadow-sm transition hover:bg-gray-50 active:scale-95"
+            aria-label="Sign in with Google"
+          >
+            <FcGoogle size={20} />
+          </button>
+          <button
+            type="button"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 bg-white shadow-sm transition hover:bg-gray-50 active:scale-95"
+            aria-label="Sign in with Apple"
+          >
+            <FaApple size={20} />
+          </button>
+        </div>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add conditional layout so auth pages omit sidebar
- redesign login page with gradient background, modern form, and social sign-in buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f6f112908332b9f0aa4dd6c0b949